### PR TITLE
feat: add contribution guideline

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -1,0 +1,68 @@
+# Contributing to `schema_to_dbml`
+
+Welcome! We're excited that you're interested in contributing to `schema_to_dbml`, an open-source project. By contributing, you can help improve the project, fix bugs, add new features, and enhance its overall quality.
+
+The following guidelines will help you understand how you can contribute effectively. We encourage you to read them carefully before getting started.
+
+## Ways to Contribute
+
+There are several ways in which you can contribute to the project:
+
+1. **Reporting Issues**: If you come across any bugs or have suggestions for improvements, please open an issue on the project's GitHub repository. Make sure to provide as much information as possible, including steps to reproduce the issue and any relevant error messages.
+
+2. **Submitting Pull Requests (PRs)**: You can help by fixing bugs, adding new features, or improving the existing codebase. If you're planning to work on a significant change, it's best to open an issue first to discuss it with the maintainers and ensure it aligns with the project's goals.
+
+## Getting Started
+
+To contribute code changes to `schema_to_dbml`, follow these steps:
+
+1. Fork the project repository to your GitHub account.
+
+2. Clone the forked repository to your local machine:
+   ```
+   git clone https://github.com/your-username/schema_to_dbml.git
+   ```
+
+3. Create a new branch for your changes:
+   ```
+   git checkout -b my-branch-name
+   ```
+
+4. Make the necessary changes and improvements to the codebase.
+
+5. Test your changes thoroughly to ensure they work as expected.
+
+6. Commit your changes with a descriptive commit message:
+   ```
+   git commit -m "Add feature XYZ"
+   ```
+
+7. Push your changes to your forked repository:
+   ```
+   git push origin my-branch-name
+   ```
+
+8. Open a pull request (PR) on the original repository. Provide a detailed description of your changes, including the problem they solve or the feature they add. Also, reference any related issues in the PR description.
+
+## Code Guidelines
+
+To maintain a consistent codebase, please adhere to the following guidelines:
+
+- Follow the existing code style and naming conventions used in the project.
+- Write clear and concise code and documentation.
+- Add tests for any new features or modifications to existing functionality.
+- Ensure that all tests pass before submitting your changes.
+
+## Communication
+
+The project's GitHub repository is the primary channel for communication. Feel free to open issues for bug reports, feature requests, or general discussions related to the project.
+
+## Code of Conduct
+
+Please note that this project follows a [Code of Conduct](https://github.com/ricardojcribeiro/schema_to_dbml/blob/develop/CODE_OF_CONDUCT.md). We expect all contributors to adhere to the code when participating in the project.
+
+## Acknowledgments
+
+Contributors play a vital role in the success of any open-source project. Your efforts and contributions will be acknowledged in the project's documentation and release notes.
+
+Thank you for your interest in contributing to `schema_to_dbml`. Together, we can make the project even better!

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This will output the generated DBML content.
 
 ## Custom Configuration
 
-If you want to customize the DBML content, you can create a YAML configuration file with your desired properties. 
+If you want to customize the DBML content, you can create a YAML configuration file with your desired properties.
 By default, the SchemaToDbml will try to load the configuration from `schema_to_dbml/configs/custom_config.yml`.
 
 Here's an example of the configuration file:
@@ -83,7 +83,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/schema_to_dbml. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/[USERNAME]/schema_to_dbml/blob/main/CODE_OF_CONDUCT.md).
+Please read the [contribution guideline](https://github.com/ricardojcribeiro/schema_to_dbml/blob/develop/CONTRIBUTE.md)
 
 ## License
 


### PR DESCRIPTION
This PR aims to include a missing contribution guideline dedicated page. Also edits the `README.md` to point to the new `CONTRIBUTE.md` file.