### PR TITLE
feat: add active support singularize method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,15 +2,25 @@ PATH
   remote: .
   specs:
     schema_to_dbml (0.0.1)
+      activesupport (>= 6.1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (7.0.4.3)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
     ast (2.4.2)
     byebug (11.1.3)
+    concurrent-ruby (1.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
+    i18n (1.13.0)
+      concurrent-ruby (~> 1.0)
     json (2.6.3)
+    minitest (5.18.0)
     parallel (1.23.0)
     parser (3.2.2.1)
       ast (~> 2.4.1)
@@ -50,6 +60,8 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
 
 PLATFORMS

--- a/lib/schema_to_dbml/dbml_relations_formatter.rb
+++ b/lib/schema_to_dbml/dbml_relations_formatter.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'active_support/inflector'
+
 class DbmlRelationsFormatter
   # Formats a database relationship for a DBML file
   #
@@ -21,26 +23,17 @@ class DbmlRelationsFormatter
 
   private
 
-  def default_foreign_key_column(to_table)
-    "#{singularize(to_table)}_id"
-  end
-
   def generate_reference_name(from_table, to_table, column)
     ref_name = "fk_rails_#{from_table}_#{to_table}"
     ref_name += "_#{column}" if column != default_foreign_key_column(to_table)
     ref_name
   end
 
-  def build_reference_string(ref_name, from_table, column, to_table)
-    "Ref #{ref_name}:#{from_table}.#{column} - #{to_table}.id"
+  def default_foreign_key_column(to_table)
+    "#{to_table.singularize}_id"
   end
 
-  # Singularizes a word
-  #
-  # @param word [String] the word to singularize
-  #
-  # @return [String] the singularized word
-  def singularize(word)
-    word.sub(/(?:([^aeiouy])y|s)$/, '\1').sub(/ies$/, 'y')
+  def build_reference_string(ref_name, from_table, column, to_table)
+    "Ref #{ref_name}:#{from_table}.#{column} - #{to_table}.id"
   end
 end

--- a/lib/schema_to_dbml/formatters/default_field_formatter_helper.rb
+++ b/lib/schema_to_dbml/formatters/default_field_formatter_helper.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
 module DefaultFieldFormatterHelper
-  DEFAULT_LAMBDA_REGEX = [/default: -> \{ "(.*?)" \}/, 'default: `\1`'].freeze
-  DEFAULT_HASH_REGEX = [/default: (\{(?:[^}]*?)\})/, 'default: \'\1\''].freeze
   DEFAULT_ARRAY_REGEX = [/default: (\[.*?\])/, 'default: \'\1\''].freeze
-  DEFAULT_STRING_REGEX = [/default: "(.*?)"/, 'default: \'\1\''].freeze
-  DEFAULT_NUMBER_REGEX = [/default: (\d+(?:\.\d+)?)/, 'default: \1'].freeze
   DEFAULT_BOOLEAN_REGEX = [/default: (true|false)/, 'default: \1'].freeze
+  DEFAULT_HASH_REGEX = [/default: (\{(?:[^}]*?)\})/, 'default: \'\1\''].freeze
+  DEFAULT_NUMBER_REGEX = [/default: (\d+(?:\.\d+)?)/, 'default: \1'].freeze
+  DEFAULT_STRING_REGEX = [/default: "(.*?)"/, 'default: \'\1\''].freeze
+  DEFAULT_LAMBDA_REGEX = [/default: -> \{ "(.*?)" \}/, 'default: `\1`'].freeze
 
   DEFAULT_PATTERNS = [
-    DEFAULT_LAMBDA_REGEX,
-    DEFAULT_HASH_REGEX,
     DEFAULT_ARRAY_REGEX,
-    DEFAULT_STRING_REGEX,
+    DEFAULT_BOOLEAN_REGEX,
+    DEFAULT_HASH_REGEX,
     DEFAULT_NUMBER_REGEX,
-    DEFAULT_BOOLEAN_REGEX
+    DEFAULT_STRING_REGEX,
+    DEFAULT_LAMBDA_REGEX
   ].freeze
 end

--- a/schema_to_dbml.gemspec
+++ b/schema_to_dbml.gemspec
@@ -39,6 +39,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'simplecov'
 
+  spec.add_dependency 'activesupport', '>= 6.1.0'
+
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html
   spec.metadata['rubygems_mfa_required'] = 'true'


### PR DESCRIPTION
This PR introduces the ActiveSupport::Inflector#singularize method to our codebase. I've noticed several instances where I am are dealing with pluralized strings and needing to convert them to their singular form. In order to standardize this process and increase its accuracy, I've decided to leverage the proven and reliable singularize method provided by the ActiveSupport library.

**Changes:**
- Added ActiveSupport as a runtime dependency in the gemspec file.
- Replaced the existing singularize method with the ActiveSupport::Inflector#singularize method.
- Updated all references to the old singularize method to now use ActiveSupport::Inflector#singularize.
