### PR TITLE
refactor: rename parsed columns to table attributes

### DIFF
--- a/lib/schema_to_dbml/build_dbml_file.rb
+++ b/lib/schema_to_dbml/build_dbml_file.rb
@@ -18,8 +18,8 @@ class SchemaConverter
   def convert(schema_content:)
     tables = []
     relations = []
-    schema_content.scan(TABLES_REGEXP).each do |table_name, table_comment, columns|
-      tables << dbml_tables_formatter.format(table_name:, table_comment:, parsed_columns: columns)
+    schema_content.scan(TABLES_REGEXP).each do |table_name, table_comment, table_attributes|
+      tables << dbml_tables_formatter.format(table_name:, table_comment:, table_attributes:)
     end
 
     schema_content.scan(RELATIONS_REGEXP).each do |from_table, to_table, column, on_delete|

--- a/lib/schema_to_dbml/dbml_tables_formatter.rb
+++ b/lib/schema_to_dbml/dbml_tables_formatter.rb
@@ -11,18 +11,18 @@ class DbmlTablesFormatter
     @configuration = configuration
   end
 
-  def format(table_name:, table_comment:, parsed_columns:)
-    columns = build_columns(parsed_columns)
+  def format(table_name:, table_comment:, table_attributes:)
+    columns = build_columns(table_attributes)
 
     format_dbml(table_name, columns, table_comment)
   end
 
   private
 
-  def build_columns(parsed_columns)
+  def build_columns(table_attributes)
     columns = []
 
-    parsed_columns.scan(COLUMNS_REGEXP).each do |type, name, default, null, comment, _precision, array, limit|
+    table_attributes.scan(COLUMNS_REGEXP).each do |type, name, default, null, comment, _precision, array, limit|
       formatted_comment = format_comment(comment:)
       formatted_default = format_default(default:)
       formatted_null = format_null(null:)

--- a/lib/schema_to_dbml/helpers/constants.rb
+++ b/lib/schema_to_dbml/helpers/constants.rb
@@ -8,7 +8,7 @@ module Helpers
       (?:,\s+force:\s+:cascade)?
       \s+do\s+\|t\|
       \n
-      (?<table_content>(?:.*?)(?:".*?")*.*?)
+      (?<table_attributes>(?:.*?)(?:".*?")*.*?)
       (?<=\n)
       \s+end
     /xm

--- a/lib/schema_to_dbml/schema_converter.rb
+++ b/lib/schema_to_dbml/schema_converter.rb
@@ -18,8 +18,8 @@ class SchemaConverter
   def convert(schema_content:)
     tables = []
     relations = []
-    schema_content.scan(TABLES_REGEXP).each do |table_name, table_comment, columns|
-      tables << dbml_tables_formatter.format(table_name:, table_comment:, parsed_columns: columns)
+    schema_content.scan(TABLES_REGEXP).each do |table_name, table_comment, table_attributes|
+      tables << dbml_tables_formatter.format(table_name:, table_comment:, table_attributes:)
     end
 
     schema_content.scan(RELATIONS_REGEXP).each do |from_table, to_table, column, on_delete|

--- a/spec/lib/schema_to_dbml/dbml_tables_formatter_spec.rb
+++ b/spec/lib/schema_to_dbml/dbml_tables_formatter_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe DbmlTablesFormatter do
   describe '#format' do
     let(:table_name) { 'users' }
     let(:table_comment) { 'Represents a user who can create blog posts and comments' }
-    let(:parsed_columns) do
+    let(:table_attributes) do
       <<~COLUMNS
         t.string "name", null: false, comment: "Name of the user"
         t.integer "age", default: 0
@@ -45,7 +45,7 @@ RSpec.describe DbmlTablesFormatter do
     end
 
     let(:perform) do
-      subject.format(table_name:, table_comment:, parsed_columns:)
+      subject.format(table_name:, table_comment:, table_attributes:)
     end
 
     before do


### PR DESCRIPTION
Solves: https://github.com/ricardojcribeiro/schema_to_dbml/issues/64#issuecomment-1927699257

This change will align the attribute name more closely with its purpose and content, making the codebase more intuitive and easier to understand for both current and future contributors.