### PR TITLE
chore: remove undercover from the project due to paid limitations

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -21,11 +21,3 @@ jobs:
     - name: Run tests
       run: |
         bundle exec rspec --require spec_helper --require schema_to_dbml
-    - name: Sync with undercover
-      if: ${{ matrix.ruby == 3.3 }}
-      run: |
-        REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f2)
-        ruby -e "$(curl -s https://undercover-ci.com/uploader.rb)" -- \
-                        --repo ${{ github.repository }} \
-                        --commit ${{ github.workflow_sha }} \
-                        --lcov coverage/lcov/$REPO_NAME.lcov

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,6 @@ GEM
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
-    simplecov-lcov (0.8.0)
     simplecov_json_formatter (0.1.4)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -96,7 +95,6 @@ DEPENDENCIES
   rubocop
   schema_to_dbml!
   simplecov
-  simplecov-lcov
 
 BUNDLED WITH
    2.4.4

--- a/schema_to_dbml.gemspec
+++ b/schema_to_dbml.gemspec
@@ -38,7 +38,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'simplecov'
-  spec.add_development_dependency 'simplecov-lcov'
 
   spec.add_dependency 'activesupport', '>= 6.1.0'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,18 +1,9 @@
 # frozen_string_literal: true
 
 require 'simplecov'
-require 'simplecov-lcov'
 
-SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
-  [
-    SimpleCov::Formatter::HTMLFormatter,
-    SimpleCov::Formatter::LcovFormatter
-  ]
-)
 SimpleCov.start do
   add_filter '/spec/'
-  enable_coverage(:branch)
 end
 
 require 'byebug'


### PR DESCRIPTION
### Description:

This pull request removes the UndercoverCI integration from the project's workflow due to limitations in the free version.

## Changes:

The conditional step in the .github/workflows/specs.yml file that attempted to upload coverage data to UndercoverCI has been removed.

UndercoverCI's free version lacks the functionalities required for integration with our workflow. Therefore, this change eliminates the error message related to the expired license and simplifies the workflow.
